### PR TITLE
Fix #8 by adding error handling to license retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ backend/data/benchmarks/
 !backend/data/benchmarks/.gitkeep
 
 .DS_Store
+/.idea/

--- a/backend/api.py
+++ b/backend/api.py
@@ -22,7 +22,7 @@ def hello_world():
 
 @app.route("/project-type-specifications", methods=['GET'])
 def repo_types():
-    return jsonify(validation_interface.get_project_type_specifcations())
+    return jsonify(validation_interface.get_project_type_specifications())
 
 
 @app.route("/validate", methods=['POST'])
@@ -34,10 +34,10 @@ def validate():
     repo_type = request_data["repoType"]
     method = request_data["method"]
 
-    returncode, report = validation_interface.run_validator(github_access_token, repo_name, repo_type, method)
+    return_code, report = validation_interface.run_validator(github_access_token, repo_name, repo_type, method)
     verbalized = verbalization_interface.run_verbalizer(report, repo_name, repo_type, method)
 
-    results = {"repoName": repo_name, "returnCode": returncode,
+    results = {"repoName": repo_name, "returnCode": return_code,
                "report": report, "verbalized": verbalized}
 
     return jsonify(results)

--- a/backend/owl_validator.py
+++ b/backend/owl_validator.py
@@ -5,7 +5,7 @@ import logging
 import fire
 import markdown
 from bs4 import BeautifulSoup
-from github import Github
+from github import Github, UnknownObjectException
 from owlready2 import (AllDifferent, AllDisjoint, DataProperty,
                        FunctionalProperty, Not, Thing, close_world,
                        get_ontology, sync_reasoner_pellet)
@@ -168,7 +168,7 @@ def create_project_type_representation():
             ]
 
 
-def get_project_type_specifcations():
+def get_project_type_specifications():
 
     create_project_type_representation()
 
@@ -244,10 +244,12 @@ def create_repository_representation(github_access_token="", repo_name="", expec
             repo_entity_params["issues"] = issue_entities
 
         # process license information
-        license = repo.get_license()
-
-        if license:
-            repo_entity_params["license"] = license.license.name
+        try:
+            license = repo.get_license()
+            if license:
+                repo_entity_params["license"] = license.license.name
+        except UnknownObjectException as e:
+            logging.exception(f"No license could be retrieved due to: {e}")
 
         # process readme information
         try:
@@ -276,7 +278,7 @@ def create_repository_representation(github_access_token="", repo_name="", expec
                 AllDifferent(section_entities)
                 repo_entity_params["readme_sections"] = section_entities
 
-        except Exception as e:
+        except UnknownObjectException as e:
             logging.exception(f"No README file could be retrieved due to: {e}")
 
         # create and thereby test repo entity against expected type

--- a/backend/validation_interface.py
+++ b/backend/validation_interface.py
@@ -21,12 +21,12 @@ def run_validator(github_access_token="", repo_name="", repo_type="", method="")
 
         try:
             output = run(cmd, capture_output=True)
-            returncode = output.returncode
+            return_code = output.returncode
         except Exception as e:
             logger.exception(e)
             
 
-        if returncode:
+        if return_code:
             stderr = output.stderr.decode()
 
             stderr = stderr.split("Explanation(s):")[1].strip()
@@ -34,13 +34,13 @@ def run_validator(github_access_token="", repo_name="", repo_type="", method="")
 
     elif method == "shacl":
 
-        returncode, report = shacl_validator.test_repo_against_specs(
+        return_code, report = shacl_validator.test_repo_against_specs(
             github_access_token, repo_name, repo_type)
         
-        logger.info(returncode)
+        logger.info(return_code)
 
         # interpret boolean to as number 
-        returncode = 0 if returncode else 1
+        return_code = 0 if return_code else 1
 
     else:
         raise NotImplementedError()
@@ -50,15 +50,15 @@ def run_validator(github_access_token="", repo_name="", repo_type="", method="")
     logger.info("Validating the %s repository against the %s project type using the %s approach took %s seconds!",
                 repo_name, repo_type, method.upper(), '{:f}'.format(time_elapsed))
 
-    return returncode, report
+    return return_code, report
 
 
-def get_project_type_specifcations():
+def get_project_type_specifications():
 
     project_type_specifcations = {
                                     "projectTypeSpecifications": {
-                                        "owl": owl_validator.get_project_type_specifcations(),
-                                        "shacl": shacl_validator.get_project_type_specifcations()
+                                        "owl": owl_validator.get_project_type_specifications(),
+                                        "shacl": shacl_validator.get_project_type_specifications()
                                     }
                                 }
 


### PR DESCRIPTION
When a repository had no license information, an internal error occured and the user did not get a result in the frontend. This pull request fixes this by adding error handling. 